### PR TITLE
fix shaking

### DIFF
--- a/src/hooks/useScroll.ts
+++ b/src/hooks/useScroll.ts
@@ -8,7 +8,7 @@ export function useScroll(scrollbarId: string): void {
       const height =
         document.documentElement.scrollHeight -
         document.documentElement.clientHeight;
-      const scrolled = (winScroll / height) * 100;
+      const scrolled = Math.min((winScroll / height) * 100, 100);
       document.getElementById(scrollbarId).style.width = scrolled + '%';
     };
   }


### PR DESCRIPTION
Progress bar overflows when the scroll is at the bottom, which leads to shaking. Fix the function which computes the width of progress bar by limiting the max value.