### PR TITLE
cleaned files before deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,3 +41,4 @@ jobs:
           username: ${{ secrets.USER }}
           password: ${{ secrets.PASSWD }}
           dotfiles: true
+          rmRemote: true


### PR DESCRIPTION
As our search crawler will regularly crawl our documentation website, having outdated files left in the cloud server will make some outdated URLs still available for crawling. In turn, it causes confusion in search results. Therefore, we should clear the files before deployment.