### PR TITLE
overwrite previous build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - '*'
 
+env:
+  new_build: ${{ secrets.REMOTE_NEW_BUILD_DIR }}
+  old_build: ${{ secrets.REMOTE_OLD_BUILD_DIR }}
+
 jobs:
   publish:
     name: Build and deploy website
@@ -36,9 +40,13 @@ jobs:
         uses: garygrossgarten/github-action-scp@release
         with:
           local: build
-          remote: ${{ secrets.REMOTE_DIR }}
+          remote: ${{ secrets.REMOTE_NEW_BUILD_DIR }}
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USER }}
           password: ${{ secrets.PASSWD }}
           dotfiles: true
           rmRemote: true
+
+      - name: 🔥 Overwrite
+        run: mv $new_build $old_build
+


### PR DESCRIPTION
If we clear the build directory when uploading the latest build, the web will be down for a while. Therefore, we should upload the latest build to a temporary directory which will be cleaned for every CI. The temporary directory will overwrite the default deployment build directory after uploading.