### PR TITLE
[hotfix] fix download page colossalai version

### DIFF
--- a/src/_pages/DownloadPage/components/InstallView/pipPackages.tsx
+++ b/src/_pages/DownloadPage/components/InstallView/pipPackages.tsx
@@ -1,12 +1,15 @@
-import api from "../../../../core/api"
 import semver from 'semver'
+import api from "../../../../core/api"
 
 export async function getPipPkgVersions(url: string): Promise<Set<string>> {
     const response = await api.get(url)
     const text = await response.raw.text()
     const pipPkgVersions: Set<string> = new Set()
-    let matched_vers = text.match(/colossalai-[0-9.]+%2B.+\.whl/g)
-    if (matched_vers){
+    // Python versioning: <public version identifier>[+<local version label>]
+    // Public version identifier: N(.N)*[{a|b|rc}N][.postN][.devN]
+    // Reference: https://peps.python.org/pep-0440/
+    let matched_vers = text.match(/colossalai-\d+(\.\d+)*((a|b|rc)\d+)?(\.post\d+)?(\.dev\d+)?%2B.+\.whl/g)
+    if (matched_vers) {
         for (let wheel of matched_vers) {
             let version = wheel.split('-')[1].replace('%2B', '+')
             pipPkgVersions.add(version)


### PR DESCRIPTION
Current code doesn't recognize pre-release version, such as `0.1.11rc1`.
![image](https://user-images.githubusercontent.com/23111350/201571963-3dfafdc3-e328-4050-b1f4-216d33537487.png)

This PR fixes the reg exp of colossalai version, which can match pre-release version:
![image](https://user-images.githubusercontent.com/23111350/201572066-e51ee579-b782-4c20-a1b1-0a9bdf7e9867.png)
