### PR TITLE
[util] added doc test utility

### DIFF
--- a/doc-build/README.md
+++ b/doc-build/README.md
@@ -46,3 +46,36 @@ cd ../docsaurus
 yarn install
 yarn start
 ```
+
+### Test the Markdown Documentation
+
+```bash
+docer test -p <path/to/markdown>
+```
+
+If you want to test the Python code in your markdown file, you need to provide a command to trigger the test. Do add the following line to the top of your file and replace `$command` with the actual command. Do note that the markdown will be converted into a Python file. Assuming you have a `demo.md` file, the test file generated will be `demo.py`. Therefore, you should use `demo.py` in your command, e.g. `python demo.py`.
+
+```markdown
+<!-- doc-test-command: $command  -->
+```
+
+Meanwhile, only code labelled as a Python code block will be considered for testing.
+
+```
+    ```python
+    print("hello world")
+    ```
+```
+
+Lastly, if you want to skip some code, you just need to add the following annotations to tell `docer` to discard the wrapped code for testing.
+
+```
+    <!--- doc-test-ignore-start -->
+    ```python
+    print("hello world")
+    ```
+    <!--- doc-test-ignore-end -->
+
+```
+
+

--- a/doc-build/docer/cli/cli.py
+++ b/doc-build/docer/cli/cli.py
@@ -1,6 +1,7 @@
 import click
+
 from .aliased_group import AliasedGroup
-from .commands import extract, docusaurus, autodoc
+from .commands import autodoc, docusaurus, extract, test
 
 __all__ = ['cli']
 
@@ -12,9 +13,11 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 def cli():
     pass
 
+
 cli.add_command(extract)
 cli.add_command(docusaurus)
 cli.add_command(autodoc)
+cli.add_command(test)
 
 if __name__ == '__main__':
     cli()

--- a/doc-build/docer/cli/commands.py
+++ b/doc-build/docer/cli/commands.py
@@ -1,9 +1,11 @@
-import click
 import os
-
-from docer.core.docs import DocManager
-from docer.core.autodoc import AutoDoc
 import subprocess
+
+import click
+from docer.core.autodoc import AutoDoc
+from docer.core.docs import DocManager
+from docer.core.doctest import DocTest
+
 
 @click.command(help="Extract the docs from the versions given in the main branch")
 @click.option('-c', '--cache', help='Directory for caching', default='.cache')
@@ -30,7 +32,7 @@ def extract(cache, owner, project):
 @click.option('-p', '--project', help='Project name')
 def autodoc(cache, owner, project):
     auto_doc = AutoDoc()
-    
+
     doc_dir = os.path.join(cache, 'docs')
 
     # list all versions in this directory
@@ -68,7 +70,10 @@ def docusaurus(cache, directory):
     doc_manager.move_to_docusaurus(directory)
 
 
-
-
-
-
+@click.command(help="Test the selected markdown file")
+@click.option('-c', '--cache', help='Directory for caching', default='.cache')
+@click.option('-p', '--path', help='Directory for the markdown file')
+def test(cache, path):
+    doc_tester = DocTest(cache)
+    nb_file_path = doc_tester.convert_markdown_to_jupyter(path)
+    doc_tester.test_notebook(nb_file_path)

--- a/doc-build/docer/core/doctest.py
+++ b/doc-build/docer/core/doctest.py
@@ -1,0 +1,63 @@
+import os
+import subprocess
+from pathlib import Path
+
+import nbformat
+from doc_builder.convert_to_notebook import generate_notebooks_from_file
+from nbconvert.exporters.python import PythonExporter
+
+
+class DocTest:
+
+    def __init__(self, cache_dir):
+        self.cache_dir = Path(cache_dir)
+        self.cache_dir.mkdir(exist_ok=True)
+
+    def convert_markdown_to_jupyter(self, markdown_path):
+        md_file_path = Path(markdown_path)
+        md_file_name = md_file_path.name
+        nb_file_name = '.'.join(md_file_name.split('.')[:-1]) + '.ipynb'
+        doc_test_path = self.cache_dir.joinpath('doc_test')
+        nb_file_path = doc_test_path.joinpath(nb_file_name)
+        generate_notebooks_from_file(markdown_path, doc_test_path)
+        return nb_file_path.absolute()
+
+    def test_notebook(self, nb_path):
+        with open(nb_path) as f:
+            nb = nbformat.read(f, as_version=4)
+
+        body, resource = PythonExporter().from_notebook_node(nb)
+        body_lines = body.split('\n')
+        new_body = []
+        command = None
+        ignore_current_line = False
+
+        for line in body_lines:
+            if 'doc-test-command' in line:
+                # intercept the test comand
+                command = line.split('doc-test-command:')[1].rstrip('-->')
+                command = command.split()
+            elif 'ignore-test-start' in line:
+                ignore_current_line = True
+            elif 'ignore-test-end' in line:
+                ignore_current_line = False
+            elif not ignore_current_line:
+                new_body.append(line)
+
+        assert command is not None, 'The test command is not provided in the documentation.'
+
+        # convert nb_path to pathlib.Path
+        if not isinstance(nb_path, Path):
+            nb_path = Path(nb_path)
+
+        filename = nb_path.name
+        python_file_name = '.'.join(filename.split('.')[:-1]) + '.py'
+        test_root_path = nb_path.parent
+        python_file_path = test_root_path.joinpath(python_file_name)
+
+        with open(python_file_path, 'w') as f:
+            f.writelines(new_body)
+
+        # launch test command
+        os.chdir(test_root_path)
+        subprocess.run(command)

--- a/doc-build/requirements.txt
+++ b/doc-build/requirements.txt
@@ -1,1 +1,2 @@
 click
+nbconvert

--- a/doc-build/third_party/hf-doc-builder/src/doc_builder/convert_to_notebook.py
+++ b/doc-build/third_party/hf-doc-builder/src/doc_builder/convert_to_notebook.py
@@ -24,7 +24,6 @@ from .convert_md_to_mdx import clean_doctest_syntax
 from .convert_rst_to_mdx import is_empty_line
 from .utils import get_doc_config
 
-
 # Re pattern that matches inline math in MDX: \\(formula\\)
 _re_math_delimiter = re.compile(r"\\\\\((.*?)\\\\\)")
 # Re pattern that matches the copyright paragraph in an MDX file
@@ -304,8 +303,7 @@ def generate_notebooks_from_file(file_name,
                                  output_dir,
                                  package=None,
                                  mapping=None,
-                                 page_info=None,
-                                 generate_script: bool = False):
+                                 page_info=None):
     """
     Generate the notebooks for a given doc file.
 

--- a/doc-build/third_party/hf-doc-builder/src/doc_builder/convert_to_notebook.py
+++ b/doc-build/third_party/hf-doc-builder/src/doc_builder/convert_to_notebook.py
@@ -166,18 +166,22 @@ def code_cell(code, output=None):
         outputs = []
     else:
         outputs = [
-            nbformat.notebooknode.NotebookNode(
-                {
-                    "data": {"text/plain": output},
-                    "execution_count": None,
-                    "metadata": {},
-                    "output_type": "execute_result",
-                }
-            )
+            nbformat.notebooknode.NotebookNode({
+                "data": {
+                    "text/plain": output
+                },
+                "execution_count": None,
+                "metadata": {},
+                "output_type": "execute_result",
+            })
         ]
-    return nbformat.notebooknode.NotebookNode(
-        {"cell_type": "code", "execution_count": None, "source": code, "metadata": {}, "outputs": outputs}
-    )
+    return nbformat.notebooknode.NotebookNode({
+        "cell_type": "code",
+        "execution_count": None,
+        "source": code,
+        "metadata": {},
+        "outputs": outputs
+    })
 
 
 def youtube_cell(youtube_id):
@@ -190,12 +194,18 @@ def youtube_cell(youtube_id):
     html_code = f'<iframe width="560" height="315" src="https://www.youtube.com/embed/{youtube_id}?rel=0&amp;controls=0&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>'
     cell_dict = {
         "cell_type": "code",
-        "metadata": {"cellView": "form", "hide_input": True},
+        "metadata": {
+            "cellView": "form",
+            "hide_input": True
+        },
         "source": ["#@title\n", "from IPython.display import HTML\n", "\n", f"HTML('{html_code}')"],
         "execution_count": None,
     }
     output_dict = {
-        "data": {"text/html": [html_code], "text/plain": ["<IPython.core.display.HTML object>"]},
+        "data": {
+            "text/html": [html_code],
+            "text/plain": ["<IPython.core.display.HTML object>"]
+        },
         "execution_count": None,
         "metadata": {},
         "output_type": "execute_result",
@@ -290,7 +300,12 @@ def create_notebook(cells):
     return nbformat.notebooknode.NotebookNode({"cells": cells, "metadata": {}, "nbformat": 4, "nbformat_minor": 4})
 
 
-def generate_notebooks_from_file(file_name, output_dir, package=None, mapping=None, page_info=None):
+def generate_notebooks_from_file(file_name,
+                                 output_dir,
+                                 package=None,
+                                 mapping=None,
+                                 page_info=None,
+                                 generate_script: bool = False):
     """
     Generate the notebooks for a given doc file.
 
@@ -305,7 +320,7 @@ def generate_notebooks_from_file(file_name, output_dir, package=None, mapping=No
         page_info (`Dict[str, str]`, *optional*):
             Some information about the page (needs to be passed to resolve doc links).
     """
-    output_dirs = [output_dir, os.path.join(output_dir, "pytorch"), os.path.join(output_dir, "tensorflow")]
+    output_dirs = [output_dir]
     output_name = Path(file_name).with_suffix(".ipynb").name
     with open(file_name, "r", encoding="utf-8") as f:
         content = f.read()


### PR DESCRIPTION
This PR added a utility command to test the markdown file.

```bash
docer test -p <path/to/markdown>
```

If you want to test the Python code in your markdown file, you need to provide a command to trigger the test. Do add the following line to the top of your file and replace `$command` with the actual command. Do note that the markdown will be converted into a Python file. Assuming you have a `demo.md` file, the test file generated will be `demo.py`. Therefore, you should use `demo.py` in your command, e.g. `python demo.py`.

```markdown
<!-- doc-test-command: $command  -->
```

Meanwhile, only code labelled as a Python code block will be considered for testing.

```
    ```python
    print("hello world")
    ```
```
Lastly, if you want to skip some code, you just need to add the following annotations to tell `docer` to discard the wrapped code for testing.
```
    <!--- doc-test-ignore-start -->
    ```python
    print("hello world")
    ```
    <!--- doc-test-ignore-end -->

```