### PR TITLE
Fix docs math rendering

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -215,6 +215,15 @@ const config = {
         ],
       },
     }),
+    stylesheets: [
+      {
+        href: 'https://cdn.jsdelivr.net/npm/katex@0.13.24/dist/katex.min.css',
+        type: 'text/css',
+        integrity:
+          'sha384-odtC+0UGzzFL/6PNoE8rX/SPcQDXBJ+uRepguP4QkPCm2LBxH3FA3y+fKSiJ+AmM',
+        crossorigin: 'anonymous',
+      },
+    ],
 };
 
 module.exports = config;


### PR DESCRIPTION
There seems to be some math rendering issues in the official website. https://colossalai.org/docs/features/1D_tensor_parallel/
![Screen Shot 2023-05-25 at 1 54 26 PM](https://github.com/hpcaitech/ColossalAI-Documentation/assets/19481308/08c4c246-d74f-42e7-92a1-95d78ae161d4)

With this PR:
![Screen Shot 2023-05-25 at 1 57 51 PM](https://github.com/hpcaitech/ColossalAI-Documentation/assets/19481308/bbc62a00-90df-4969-bf65-855f2018fba2)

I mostly followed this tutorial https://docusaurus.io/docs/markdown-features/math-equations.